### PR TITLE
Migrate from `pykalman` to `pykalman-brado`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ orjson = "^3.7.5"
 ncls = "^0.0.65"
 dill = "^0.3.5"
 pathos = "^0.2.9"
-pykalman-bardo = "^0.9.6"
+pykalman-bardo = "^0.9.7"
 scikit-learn = "^1.1.1"
 torchmetrics = "0.6.2"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ orjson = "^3.7.5"
 ncls = "^0.0.65"
 dill = "^0.3.5"
 pathos = "^0.2.9"
-pykalman = "^0.9.5"
+pykalman-bardo = "^0.9.6"
 scikit-learn = "^1.1.1"
 torchmetrics = "0.6.2"
 


### PR DESCRIPTION
Consider migration from `pykalman` to `pykalman-bardo`, as [pykalman](https://github.com/pykalman/pykalman) project is no longer maintained. There were some issues that were fixed, see: https://github.com/pybardo/pykalman/blob/v0.9.7/CHANGELOG

I'm going to maintain [pykalman-bardo](https://github.com/pybardo/pykalman), react to issues, and fix bugs. For now the API is the same as in the initial package, but it might evolve in time.

I hope you will find it useful for your project!